### PR TITLE
Rename pkg name (was using '-')

### DIFF
--- a/sndfile.babel
+++ b/sndfile.babel
@@ -1,5 +1,5 @@
 [Package]
-name: "nim-sndfile"
+name: "sndfile"
 version: "0.1.0"
 author: "Julien Aubert"
 description: "Wrapper for libsndfile"


### PR DESCRIPTION
`nimble install` fails on installing `nim-sndfile` (see https://github.com/nim-lang/packages/issues/553)